### PR TITLE
Relax version bounds and use newest stack resolver

### DIFF
--- a/fortytwo.cabal
+++ b/fortytwo.cabal
@@ -35,8 +35,8 @@ library
                        FortyTwo.Renderers.Select
                        FortyTwo.Renderers.Multiselect
   build-depends:       base >= 4.7 && < 5,
-                       text <= 1.2.2.2,
-                       ansi-terminal >= 0.6.0.0 && <= 0.7.1.1
+                       text <= 1.3,
+                       ansi-terminal >= 0.6.0.0 && <= 0.9
   default-language:    Haskell2010
 
 executable             demo
@@ -63,8 +63,8 @@ Test-Suite spec
                      Specs.Utils
   hs-source-dirs:    test
   build-depends:     fortytwo,
-                     base >=4.9 && <4.10,
-                     process >=1.4 && <1.5,
+                     base >=4.9 && <5,
+                     process >=1.4 && <1.7,
                      async >=2.1 && <2.2,
                      hspec >= 2.2
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-9.9
+resolver: lts-11.14
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
The current bounds are too restrictive to e.g., build it on nixos.

I updated the bounds and checked that it compiles with the old stack resolver as well as the newest one and decided to change it to the latter.