### PR TITLE
Bump ansi-terminal upper bound to <= 0.12

### DIFF
--- a/fortytwo.cabal
+++ b/fortytwo.cabal
@@ -36,7 +36,7 @@ library
                        FortyTwo.Renderers.Multiselect
   build-depends:       base >= 4.7 && < 5,
                        text <= 1.3,
-                       ansi-terminal >= 0.6.0.0 && <= 0.8.2
+                       ansi-terminal >= 0.6.0.0 && <= 0.12
   default-language:    Haskell2010
 
 executable             demo


### PR DESCRIPTION
The `ansi-terminal` does currently not build for me, because of an old version of `ansi-terminal` as the upper bound.

I tested it with `ansi-terminal == 0.11` and it works fine, so I changed the bound.